### PR TITLE
refactor: publish icons at root

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,53 @@
+version: 2
+jobs:
+  test:
+    docker:
+      - image: circleci/node:12.0
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v2-dependencies-{{ checksum "package.json" }}
+            - v2-dependencies-
+
+      - run: yarn
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v2-dependencies-{{ checksum "package.json" }}
+
+      - run: yarn test
+
+  build:
+    docker:
+      - image: circleci/node:12.0
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v2-dependencies-{{ checksum "package.json" }}
+            - v2-dependencies-
+
+      - run: yarn
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v2-dependencies-{{ checksum "package.json" }}
+
+      - run: yarn build
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -15,9 +15,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Install
         run: yarn install
-      - name: Build
-        run: yarn build
       - name: Publish
-        run: yarn publish --access public
+        run: yarn release
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+scripts

--- a/README.md
+++ b/README.md
@@ -31,18 +31,31 @@ Icons can be configured with `color`, `size` and any SVG props:
 ```ts
 <GitHub color="red" size={36} />
 <GitHub color="blue" strokeWidth={2} />
-
 ```
 
-You can also include the whole icon pack:
+## Other ways
+
+1. You can include the whole icon pack:
 
 ```tsx
-import React from 'react'
 import * as Icon from '@zeit-ui/react-icons'
 
 const App = () => {
   return <Icon.GitHub />
 }
-
-export default App
 ```
+
+2. You can include single icon:
+
+```tsx
+import Activity from '@zeit-ui/react-icons/activity'
+
+const App = () => {
+  return <Activity />
+}
+```
+
+<br/>
+
+## LICENSE
+[MIT](https://raw.githubusercontent.com/zeit-ui/react-icons/master/LICENSE)

--- a/package.json
+++ b/package.json
@@ -2,19 +2,18 @@
   "name": "@zeit-ui/react-icons",
   "description": "React icon components based on Vercel Design",
   "version": "1.0.0",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "index.js",
+  "module": "index.js",
+  "types": "index.d.ts",
   "author": "Ofek Ashery",
   "license": "MIT",
   "scripts": {
     "start": "yarn build",
-    "build": "ts-node src/generate.ts",
-    "test": "ava"
+    "build": "ts-node src/generate.ts && node scripts/pre-release.js",
+    "test": "ava",
+    "release": "yarn build && cd dist && yarn publish --access public",
+    "prepublishOnly": "node scripts/check-release.js"
   },
-  "files": [
-    "/dist"
-  ],
   "peerDependencies": {
     "@zeit-ui/react": ">=1.0.0-rc.3",
     "react": ">=16.13.0"

--- a/scripts/check-release.js
+++ b/scripts/check-release.js
@@ -1,0 +1,11 @@
+const fs = require('fs-extra')
+const path = require('path')
+
+const dist = path.join(process.cwd(), 'dist')
+
+;(async() => {
+  if (fs.existsSync(dist)) {
+    console.log('> Abort. Release at root is not allowed.\n')
+    process.exit(1)
+  }
+})()

--- a/scripts/pre-release.js
+++ b/scripts/pre-release.js
@@ -1,0 +1,20 @@
+const fs = require('fs-extra')
+const path = require('path')
+const outputPath = path.join(__dirname, '../dist')
+const rootPath = path.join(__dirname, '../')
+const shouldMovedFiles = [
+  'LICENSE',
+  'README.md',
+  'package.json',
+  'scripts',
+  '.npmignore',
+]
+
+;(async () => {
+  await Promise.all(shouldMovedFiles.map(async name => {
+    const filePath = path.join(rootPath, name)
+    const outputFilePath = path.join(outputPath, name)
+    await fs.copy(filePath, outputFilePath)
+  }))
+  console.log('All files moved.')
+})()

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,7 +1,8 @@
 import fetch from 'node-fetch'
 import { JSDOM } from 'jsdom'
-import * as fs from 'fs-extra'
-import * as babel from '@babel/core'
+import fs from 'fs-extra'
+import { transform } from '@babel/core'
+import { moduleBabelConfig, allModulesBabelConfig,replaceAll } from './utils'
 
 export default (async () => {
   await fs.remove('./dist')
@@ -38,10 +39,7 @@ export default ${componentName};`
 
     return fs.outputFile(
       `${__dirname}/../dist/${componentName}.js`,
-      babel.transform(component, {
-        presets: ['@babel/preset-react', '@babel/preset-env'],
-        minified: true
-      }).code
+      transform(component, moduleBabelConfig).code
     )
   })
 
@@ -49,15 +47,9 @@ export default ${componentName};`
   await fs.outputFile(`${__dirname}/../dist/index.d.ts`, definition)
   await fs.outputFile(
     `${__dirname}/../dist/index.js`,
-    babel.transform(exports, {
-      presets: ['@babel/preset-env'],
-      minified: true
-    }).code
+    transform(exports, allModulesBabelConfig).code
   )
 })()
-
-const replaceAll = (target: string, find: string, replace): string =>
-  target.split(find).join(replace)
 
 const parseSvg = (svg: string, styles: any) => {
   // Reactify attrs

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,19 @@
+
+export const moduleBabelConfig = {
+  presets: ['@babel/preset-react', '@babel/preset-env'],
+  minified: true
+}
+
+export const allModulesBabelConfig = {
+  presets: ['@babel/preset-env'],
+  minified: true
+}
+
+export const replaceAll = (
+  target: string,
+  find: string,
+  replace: string,
+): string => {
+  return target.split(find).join(replace)
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "outDir": "./dist/",
     "sourceMap": false,
     "noImplicitAny": false,
+    "esModuleInterop": true,
     "module": "commonjs",
     "target": "es2015"
   },


### PR DESCRIPTION
Optimize the improt of a single icon:

```
// before
import Activity from '@zeit-ui/react-icons/dist/activity'

// after
import Activity from '@zeit-ui/react-icons/activity'
```


resolved #5 
