### PR TITLE
refactor: the exported filename uses the hump style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zeit-ui/react-icons",
   "description": "React icon components based on Vercel Design",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "index.js",
   "module": "index.js",
   "types": "index.d.ts",

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -2,7 +2,10 @@ import fetch from 'node-fetch'
 import { JSDOM } from 'jsdom'
 import fs from 'fs-extra'
 import { transform } from '@babel/core'
-import { moduleBabelConfig, allModulesBabelConfig, replaceAll } from './utils'
+import {
+  moduleBabelConfig, allModulesBabelConfig, replaceAll,
+  toHumpName, toComponentName,
+} from './utils'
 
 const sourceFile = `${__dirname}/../.source`
 
@@ -29,8 +32,8 @@ type Icon = React.FunctionComponent<Props>;\n`
   const icons = document.querySelectorAll('.geist-list .icon')
   const promises = Array.from(icons).map((icon: Element) => {
     const name: string = icon.querySelector('.geist-text').textContent
-    const componentName =
-      name.slice(0, 1).toUpperCase() + name.slice(1).replace(/-(.)/g, (g) => g[1].toUpperCase())
+    const componentName = toComponentName(name)
+    const fileName = toHumpName(name)
 
     const svg = icon.querySelector('svg')
     const styles = parseStyles(svg.getAttribute('style'))
@@ -43,11 +46,11 @@ const ${componentName} = ({ color, size, ...props }) => {
 }
 export default ${componentName};`
 
-    exports += `export { default as ${componentName} } from './${componentName}';\n`
+    exports += `export { default as ${componentName} } from './${fileName}';\n`
     definition += `export const ${componentName}: Icon;\n`
 
     return fs.outputFile(
-      `${__dirname}/../dist/${componentName}.js`,
+      `${__dirname}/../dist/${fileName}.js`,
       transform(component, moduleBabelConfig).code
     )
   })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,3 +17,14 @@ export const replaceAll = (
   return target.split(find).join(replace)
 }
 
+export const toHumpName = (name: string): string => {
+  return name.replace(/-(.)/g, (g) => g[1].toUpperCase())
+}
+
+export const toComponentName = (name: string): string => {
+  const first = name.slice(0, 1).toUpperCase()
+  const last = toHumpName(name.slice(1))
+  return `${first}${last}`
+}
+
+


### PR DESCRIPTION
The exported file name style changes as follows:

```js
// before
import Activity from '@zeit-ui/react-icons/Activity'

// after
import Activity from '@zeit-ui/react-icons/activity'
```

Keep up with style here: `https://cdn.jsdelivr.net/npm/@zeit-ui/react@1.0.0-rc.3/dist/button.js`